### PR TITLE
RF without pruning by default

### DIFF
--- a/Orange/classification/random_forest.py
+++ b/Orange/classification/random_forest.py
@@ -25,7 +25,7 @@ class RandomForestLearner(SklLearner, _FeatureScorerMixin):
     name = 'random forest'
 
     def __init__(self, n_estimators=10, max_features="auto",
-                 random_state=None, max_depth=3, max_leaf_nodes=5,
+                 random_state=None, max_depth=None, max_leaf_nodes=None,
                  preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()


### PR DESCRIPTION
Brieman: "Each tree is grown to the largest extent possible. There is no pruning."

We should probably use that as default. It yields much better performance.

More info: http://stats.stackexchange.com/questions/36298/why-is-pruning-not-needed-for-random-forest-trees